### PR TITLE
Update acronym on DPG

### DIFF
--- a/docs/introduction/how-to-use-this-guide.md
+++ b/docs/introduction/how-to-use-this-guide.md
@@ -5,11 +5,11 @@ slug: /
 
 # How to Use this Guide
 
-This guide is meant to be directive, with a collection of many relevant cases, templates and resources to help accelerate setting up a pipeline of locally developed DPGs that are addressing national priorities and are regionally scalable. It seeks to cover all the crucial steps from scoping the initiative with public and private partners to graduating DPGs providing tools and templates along the way that can be tailored as needed.  It is a living document meant to be updated through public input as more organizations accelerate DPGs. You can participate in its continued development and suggest changes at https://github.com/unicef/publicgoods-accelerator-guide.  If you are new to Github, you can view this [short description](https://docs.google.com/document/d/1axBDyG1MK24s9FyxeMcguqFgg1-nCGa1FXWwBMDqfKE/edit?usp=sharing) (1-2 mins read) on how to contribute to the guide, including giving direct feedback and making proposed edits to the text in the guide.
+This guide is meant to be directive, with a collection of many relevant cases, templates and resources to help accelerate setting up a pipeline of locally developed Digital Public Goods (DPG) that are addressing national priorities and are regionally scalable. It seeks to cover all the crucial steps from scoping the initiative with public and private partners to graduating DPGs providing tools and templates along the way that can be tailored as needed.  It is a living document meant to be updated through public input as more organizations accelerate DPGs. You can participate in its continued development and suggest changes at https://github.com/unicef/publicgoods-accelerator-guide.  If you are new to Github, you can view this [short description](https://docs.google.com/document/d/1axBDyG1MK24s9FyxeMcguqFgg1-nCGa1FXWwBMDqfKE/edit?usp=sharing) (1-2 mins read) on how to contribute to the guide, including giving direct feedback and making proposed edits to the text in the guide.
 
 **Primarily this guide will cover:**
 
-### 1. Introduction to DPGs
+### 1. Introduction to Digital Public Goods (DPGs)
   * Why go Open Source? (Myths about Open Source, Benefits, Challenges)
   * What are Digital Public Goods (DPGs)?  Why should I care as an accelerator? (Accelerator Perks)
   * What are the benefits for various stakeholders?


### PR DESCRIPTION
Spelling out the first use of the term Digital Public Goods on the page instead of DPG.