### PR TITLE
Update accelerator-perks.md

### DIFF
--- a/docs/bizmodels-dpgs/accelerator-perks.md
+++ b/docs/bizmodels-dpgs/accelerator-perks.md
@@ -2,36 +2,36 @@
 sidebar_position: 2
 ---
 
-# Accelerator Perks of Supporting Digital Public Goods (DPGs)
+# Accelerator Perks of Supporting DPGs
 
-In short, when a startup creates a Digital Public Good, it opens avenues for primarily scaling a startup, through the following:
+When a startup creates a digital public good, it opens avenues for scaling a startup in the following ways:
 
-1. **Global Network:** Amongst UNICEF, Digital Public Goods Alliance (DPGA), and other partners, UNICEF and other DPGA roadmap members work with startup ecosystems, government agencies and field experts to connect your startups to stakeholders who can potentially support the startup's solution to be recognized as a DPG.  This also can include a wider contribution from the IT community which is important for the active open source aspect. The Digital Public Goods solution that your accelerator chooses to support will be included in the Alliances recommended packages for governments and UN agencies.  Your accelerator can also gain the global network from DPGA members to find a pipeline of potential solutions to participate in your programme.
+1. **Create a global network:** UNICEF, DPGA, DPGA roadmap members work with startup ecosystems, government agencies and field experts to connect your startups to stakeholders who can potentially support the startup's solution to be recognized as a DPG.  This also can include a wider contribution from the IT community which is important for the active open source aspect. The DPG that your accelerator supports could potentially be considered or included in reccommendations made to governments and UN agencies seeking open source solutions by UNICEF or the DPGA.  Your accelerator can also make global network connections from DPGA members.
 
-2. **Access to Experts from Communities of Practice (CoPs):**  In the Communities of Practice, DPGA convene experts from different organizations to align on definitions, processes and to collectively identify, assess and advance critical digital solutions. CoPs are a means of leveraging years of experience from individuals operating in relevant sectors that have gained invaluable insights into implementation processes and development needs, who can collectively accelerate the achievement of the sustainable development goals. The DPGA convenes communities of practice in areas such as climate change adaptation, financial inclusion, and of course, health.
+2. **Potential relevence to the DPGA's communities of practice:**  The DPGA convenes communities of practice (CoP) to bring together experts from different organizations to align on definitions, processes and collectively identify, assess and advance the use of DPGs that can help meet critical needs relevent to the sustainable development goals. CoPs are a means of leveraging years of experience from individuals working in relevant sectors that have gained invaluable insights into implementation processes and development needs. The DPGA convenes communities of practice in areas such as climate change adaptation, financial inclusion, and health.
 
-3. **The potential scale and growth of the startup participating in your programme:** The startups you support in your accelerator program can potentially be adapted and solve challenges in other countries, giving it the geographic scale and growth quicker than a proprietary business. If the startup's solution meets the DPG Standard, it will be officially considered a Digital Public Good, and will allow the startup to promote the solution as one endorsed in line with global technical standards.  
+3. **The potential scale and growth of the startup participating in your programme:** The startups you support in your accelerator program can potentially be adapted and solve challenges in other countries, giving it the geographic scale and growth quicker than a proprietary business. If the startup's solution meets the DPG Standard, it will be officially considered a digital public good, which will allow the startup to promote the solution as one in line with global standards.  
 
-4. **Branding and media exposure in the startup ecosystem (national, regional and global reach):** Once a startup solution is recognized as a Digital Public Good, your work as an accelerator and the solution will be made visible to an audience of global government counterparts, NGOs, and non-profit organizations.   The DPGA and its platform has been endorsed by the UN Secretary General and aims to become the global go-to-platform for open source solutions. By submitting a startup solution that can potentially be recognized as DPG, it will make your work as an accelerator visible to a broad audience of governments, NGOs, and non-profit organizations.  
+4. **Brand and media exposure in the startup ecosystem (national, regional and global reach):** Once a solution is recognized as a digital public good, your work as an accelerator and the DPG itself is made visible to a global audience including governments, NGOs, and non-profit organizations. The DPGA is endorsed by the UN Secretary General's Roadmap for Digital Cooperation, and it's DPG Registry aspries to become a global go-to-platform for open source solutions. By nominating a startup solution to become a DPG, it will make your work as an accelerator visible to a broad audience.  
 
-5. **Deployment opportunities:** UNICEF and other Alliance partners are working directly with national governments, UN agencies, and others who are looking for open source solutions to deploy in their countries. As part of the platform, the Alliance can include the startup solutions you support in these explorations.
+5. **Deployment opportunities:** UNICEF and other DPGA partners are working directly with national governments, UN agencies, and others who are looking for open source solutions to deploy in their countries. As part of the platform, the DPGA includes DPGs in these explorations.
 
-6. **Follow on funding and support for the startup:** The Alliance is developing partnerships with organisations and investors who can provide your solution with the next level of financing and technical assistance.
+6. **Follow on funding and support for the startup:** The DPGA is developing partnerships with organisations and investors who can provide your solution with the next level of financing and technical assistance.
 
-7. **Mentorship by Tech Companies:** With DPGA's and its Alliance members' network of corporate partners, there is potential for collaboration and technical mentorship for the startups.
+7. **Mentorship by Tech Companies:** With the DPGA and their member's network of corporate partners, there is potential for collaboration and technical mentorship for the startups.
 
-## What happens after the startup solution gets endorsed as a Digital Public Good by DPGA?
-DPGA is constantly adding additional offerings to support vetted digital public goods, below is a quick summary of the current and upcoming benefits to be recognized as a digital public good.
+## What happens after the startup solution gets endorsed as a digital public good by DPGA?
+DPGA is constantly adding additional offerings to support vetted DPGs, below is a quick summary of the current and upcoming benefits to be recognized as a digital public good.
 
 **Current:**
 * Assessed projects will be informed by the DPGA
 * Displayed on the DPGA website 
 * Announced through the DPGA’s blog and mailing lists
-* The project’s designation will be reflected on connected platforms such as [DIAL’s](https://solutions.dial.community/) digital public goods catalog where it can easily be discovered by implementers, partners and funders
+* The project’s designation will be reflected on connected platforms such as [DIAL’s](https://solutions.dial.community/) Catalog of Digital Solutions where it can easily be discovered by implementers, partners and funders
 * Projects are empowered to describe themselves as approved DPGs by the DPGA 
 * Projects are encouraged to work with the DPGA to identify other ways for the DPGA to support and amplify the project, brand and mission
 
 **Upcoming:**
-* We are working with additional partners to establish visual icons and indicators to increase the discoverability and prominence of vetted digital public goods 
+* We are working with additional partners to establish visual icons and indicators to increase the discoverability and prominence of DPGs 
 * DPGs will be eligible to be included in additional assessments by communities of experts seeking to make recommendations specifically to government procurers and funding bodies
 * Additional offerings for recognized DPGs including mentorship, consultation, and funding


### PR DESCRIPTION
Each section title only has (DPGs) in it... I suggest just always saying one or the other for section titles.

#1 is unclear - are we saying we can help them become DPGs? Sentence following suggesting re: contribution - does that mean get the expertise needed for making potential changes required to meet the DPG Standard? Or does it mean open source contribution in the traditional sense of OS contributors? Also, has this section been vetted by others? Im concerned about indicating we will recommend DPGs to UN agencies/governments. I tried to tone this language down so its not a promise. I deleted the last sentence as I was not sure what was meant by it.

#2 Change title to be more accurate. DPGs don't get access to experts directly necessarily. 

#4 Suggest to add hyperlink for SG's roadmap.

#6 concerned that this point is overpromising.

#5 feels repetitive, not sure if needed